### PR TITLE
version 1.2.6: allow * path

### DIFF
--- a/ezyhttp-client/pom.xml
+++ b/ezyhttp-client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-client</artifactId>

--- a/ezyhttp-core/pom.xml
+++ b/ezyhttp-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-core</artifactId>

--- a/ezyhttp-core/src/main/java/com/tvd12/ezyhttp/core/net/PathVariables.java
+++ b/ezyhttp-core/src/main/java/com/tvd12/ezyhttp/core/net/PathVariables.java
@@ -1,10 +1,10 @@
 package com.tvd12.ezyhttp.core.net;
 
+import com.tvd12.ezyfox.util.EzyEntry;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
-
-import com.tvd12.ezyfox.util.EzyEntry;
 
 public final class PathVariables {
 
@@ -23,6 +23,17 @@ public final class PathVariables {
                 String varName = getVariableName(templatePath);
                 String varValue = uriPaths[i];
                 answer.add(EzyEntry.of(varName, varValue));
+            } else if (templatePath.equals("*")) {
+                StringBuilder varValue = new StringBuilder();
+                int lastIndex = uriPaths.length - 1;
+                for (; i < uriPaths.length; ++i) {
+                    varValue.append(uriPaths[i]);
+                    if (i < lastIndex) {
+                        varValue.append("/");
+                    }
+                }
+                answer.add(EzyEntry.of("*", varValue.toString()));
+                break;
             }
         }
         return answer;

--- a/ezyhttp-core/src/main/java/com/tvd12/ezyhttp/core/net/URITree.java
+++ b/ezyhttp-core/src/main/java/com/tvd12/ezyhttp/core/net/URITree.java
@@ -41,7 +41,8 @@ public class URITree {
                 child = lastChild.children.get("{}");
             }
             if (child == null) {
-                return null;
+                child = lastChild.children.get("*");
+                return child == null ? null : child.uri;
             }
             lastChild = child;
         }

--- a/ezyhttp-core/src/test/java/com/tvd12/ezyhttp/core/test/net/PathVariablesTest.java
+++ b/ezyhttp-core/src/test/java/com/tvd12/ezyhttp/core/test/net/PathVariablesTest.java
@@ -1,14 +1,15 @@
 package com.tvd12.ezyhttp.core.test.net;
 
-import java.util.List;
-import java.util.Map.Entry;
-
-import org.testng.annotations.Test;
-
+import com.tvd12.ezyfox.util.EzyMapBuilder;
 import com.tvd12.ezyhttp.core.net.PathVariables;
 import com.tvd12.test.assertion.Asserts;
 import com.tvd12.test.base.BaseTest;
 import com.tvd12.test.performance.Performance;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 public class PathVariablesTest extends BaseTest {
 
@@ -29,5 +30,52 @@ public class PathVariablesTest extends BaseTest {
         Asserts.assertFalse(PathVariables.isPathVariable("{a"));
         Asserts.assertFalse(PathVariables.isPathVariable("a"));
         Asserts.assertFalse(PathVariables.isPathVariable("a}"));
+    }
+
+    @Test
+    public void anyPathTest() {
+        // given
+        String template = "/market/items/{projectName}/java/docs/*";
+        String uri = "/market/items/hello/java/docs/world/index.html";
+
+        // when
+        List<Entry<String, String>> actual = PathVariables.getVariables(
+            template,
+            uri
+        );
+
+        // then
+        Asserts.assertEquals(
+            actual.stream()
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue)),
+            EzyMapBuilder.mapBuilder()
+                .put("projectName", "hello")
+                .put("*", "world/index.html")
+                .build()
+        );
+    }
+
+    @Test
+    public void anyPathComplexTest() {
+        // given
+        String template = "/versions/{ezyplatformVersion}/java-docs/{moduleName}/*";
+        String uri = "/versions/0.0.2/java-docs/ezyplatform-web/org/youngmonkeys/ezyplatform/web/package-frame.html";
+
+        // when
+        List<Entry<String, String>> actual = PathVariables.getVariables(
+            template,
+            uri
+        );
+
+        // then
+        Asserts.assertEquals(
+            actual.stream()
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue)),
+            EzyMapBuilder.mapBuilder()
+                .put("ezyplatformVersion", "0.0.2")
+                .put("moduleName", "ezyplatform-web")
+                .put("*", "org/youngmonkeys/ezyplatform/web/package-frame.html")
+                .build()
+        );
     }
 }

--- a/ezyhttp-core/src/test/java/com/tvd12/ezyhttp/core/test/net/URITreeTest.java
+++ b/ezyhttp-core/src/test/java/com/tvd12/ezyhttp/core/test/net/URITreeTest.java
@@ -64,4 +64,20 @@ public class URITreeTest {
         Asserts.assertNull(tree.getMatchedURI("/api/v1/hello/{world}/{foo}"));
         Asserts.assertNull(tree.getMatchedURI("/api/v1/hello/{world}/{foo}/{bar}/unknown"));
     }
+
+    @Test
+    public void matchAllTest() {
+        // given
+        URITree tree = new URITree();
+        tree.addURI("/market/items/hello/java/docs/*");
+
+        // when
+        // then
+        System.out.println(tree);
+        Asserts.assertNull(tree.getMatchedURI("/market/items/hello/java"));
+        Asserts.assertNull(tree.getMatchedURI("/market/items/hello/java/docs"));
+        Asserts.assertNull(tree.getMatchedURI("/market/items/hello/java/docs/"));
+        Asserts.assertNotNull(tree.getMatchedURI("/market/items/hello/java/docs/index.html"));
+        Asserts.assertNotNull(tree.getMatchedURI("/market/items/hello/java/docs/com/tvd12/index.html"));
+    }
 }

--- a/ezyhttp-server-boot/pom.xml
+++ b/ezyhttp-server-boot/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-server-boot</artifactId>

--- a/ezyhttp-server-core/pom.xml
+++ b/ezyhttp-server-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-server-core</artifactId>

--- a/ezyhttp-server-graphql/pom.xml
+++ b/ezyhttp-server-graphql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
     <artifactId>ezyhttp-server-graphql</artifactId>
 

--- a/ezyhttp-server-jetty/pom.xml
+++ b/ezyhttp-server-jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-server-jetty</artifactId>

--- a/ezyhttp-server-management/pom.xml
+++ b/ezyhttp-server-management/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
     <artifactId>ezyhttp-server-management</artifactId>
     <name>ezyhttp-server-management</name>

--- a/ezyhttp-server-thymeleaf/pom.xml
+++ b/ezyhttp-server-thymeleaf/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
     <artifactId>ezyhttp-server-thymeleaf</artifactId>
 

--- a/ezyhttp-server-tomcat/pom.xml
+++ b/ezyhttp-server-tomcat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tvd12</groupId>
         <artifactId>ezyhttp</artifactId>
-        <version>1.2.5</version>
+        <version>1.2.6</version>
     </parent>
 
     <artifactId>ezyhttp-server-tomcat</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <version>1.0.6</version>
     </parent>
     <artifactId>ezyhttp</artifactId>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <packaging>pom</packaging>
 
     <name>ezyhttp</name>


### PR DESCRIPTION
Example:

```java
// given
String template = "/versions/{ezyplatformVersion}/java-docs/{moduleName}/*";
String uri = "/versions/0.0.2/java-docs/ezyplatform-web/org/youngmonkeys/ezyplatform/web/package-frame.html";

// when
List<Entry<String, String>> actual = PathVariables.getVariables(
    template,
    uri
);

// then
Asserts.assertEquals(
    actual.stream()
        .collect(Collectors.toMap(Entry::getKey, Entry::getValue)),
    EzyMapBuilder.mapBuilder()
        .put("ezyplatformVersion", "0.0.2")
        .put("moduleName", "ezyplatform-web")
        .put("*", "org/youngmonkeys/ezyplatform/web/package-frame.html")
        .build()
);
```